### PR TITLE
metalsmith.dir has changed, extraRequire option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,8 @@
             outputStyle = this.outputStyle || 'compressed',
             imagePath = this.imagePath || '/',
             outputDir = this.outputDir || path.dirname(filename),
-            trace = this.trace;
+            trace = this.trace, 
+            extraRequire = this.extraRequire;
 
         if (isSassFile(filename) === true) {
 
@@ -34,6 +35,10 @@
 
           if(includes) {
             args.push('--load-path', includes);
+          }
+
+          if(extraRequire) {
+            args.push('--require', extraRequire);
           }
 
           args.push('--style', outputStyle);
@@ -74,7 +79,7 @@
       },
 
       compileSass = function compileSass(files, metalsmith, done) {
-        var basePath = path.join(metalsmith.dir, metalsmith._src);
+        var basePath = path.join(metalsmith._directory, metalsmith._source);
         each(Object.keys(files), compile.bind(this, basePath, files), done);
       },
 


### PR DESCRIPTION
I ran into same issue as described at stevenschobert#9) and quickly patched .dir and ._src to new names.

Also since I needed to use sass-globbing in one of my projects I put in an extra option to pass in a specific require - if you find useful feel free to merge. Otherwise the .dir fix is a one-liner easily applied.

Admittedly also did not run tests or add new for the extraRequire option.
